### PR TITLE
Add interactive garden background

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Each click symbolizes an act of peace, kindness, or positive dialogue, gradually
 - **Click:** Plant a "Seed of Peace" that visually transforms the landscape.
 - **Idle Actions:** Automate peace-building through symbolic characters (Teachers, Advocates, Artists).
 - **Milestones:** Unlock educational content, real-world stories of peace, and conflict resolution inspiration.
+- **Dynamic Background:** Starts in a blurred grayscale state and becomes clearer with each planted seed, celebrating milestones with a colorful flourish.
 
 ### Monetization Model 💰
 

--- a/index.html
+++ b/index.html
@@ -19,11 +19,12 @@ CopyLeft 2020 Michael Rouves
 
 <html>
 <head>
-	<title>Clicker Game !</title>
-	<link rel="stylesheet" media="screen" href="style.css">
-	<meta charset="utf-8">
+        <title>Clicker Game !</title>
+        <link rel="stylesheet" media="screen" href="style.css">
+        <meta charset="utf-8">
 </head>
 <body>
+        <div id="background"></div>
         <!-- PLAYER MONEY -->
         <p id="money" class="money-text"></p>
         <p id="seeds" class="money-text"></p>

--- a/script.js
+++ b/script.js
@@ -25,6 +25,11 @@ var money = 0,//global player's money
         interval,//auto money interval
         peaceSeeds = 0;//counts planted seeds
 
+//background effect variables
+var background = document.getElementById("background"),
+        blurLevel = 5,
+        grayLevel = 100;
+
 // HTML MAIN ELEMENTS (except  shop buttons)
 var element = {
         clicker   : document.getElementById("main-clicker"),//button
@@ -44,6 +49,17 @@ function updateMoney(check=true) {//update html money txt
 }
 function updateSeeds(){
   element.seeds.innerHTML = "Peace Seeds planted: " + peaceSeeds;
+}
+function updateBackground(){
+  blurLevel = Math.max(0, blurLevel - 0.1);
+  grayLevel = Math.max(0, grayLevel - 2);
+  background.style.filter = "grayscale("+grayLevel+"%) blur("+blurLevel+"px)";
+}
+function checkMilestones(){
+  if([50,100,500].includes(peaceSeeds)){
+    background.classList.add('flourish');
+    setTimeout(function(){background.classList.remove('flourish');},2000);
+  }
 }
 function autoMoney(amount) {//auto add money every interval
   clearInterval(interval);
@@ -154,6 +170,8 @@ element.clicker.onclick = function() {
         updateMoney();
         peaceSeeds += 1;
         updateSeeds();
+        updateBackground();
+        checkMilestones();
         element.clicker.disabled = false;
 };
 

--- a/style.css
+++ b/style.css
@@ -25,8 +25,33 @@ CopyLeft 2020 Michael Rouves
 			================= BODY =================
 */
 body{
-	background: rgb(15,232,146);
-	background: radial-gradient(circle, rgba(15,232,146,1) 0%, rgba(11,186,131,1) 31%, rgba(8,129,153,1) 100%);
+        background: rgb(15,232,146);
+        background: radial-gradient(circle, rgba(15,232,146,1) 0%, rgba(11,186,131,1) 31%, rgba(8,129,153,1) 100%);
+        overflow: hidden;
+}
+
+#background {
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background-image: url('https://images.unsplash.com/photo-1501004318641-b39e6451bec6');
+        background-size: cover;
+        background-position: center;
+        filter: grayscale(100%) blur(5px);
+        z-index: -1;
+        transition: filter 0.5s;
+}
+
+.flourish {
+        animation: flourish 2s ease;
+}
+
+@keyframes flourish {
+        0% { filter: grayscale(0%) brightness(1); }
+        50% { filter: grayscale(0%) brightness(1.5); }
+        100% { filter: grayscale(0%) brightness(1); }
 }
 
 /* 


### PR DESCRIPTION
## Summary
- add a fixed `#background` container sourced from Unsplash
- reduce blur and grayscale after each click via JavaScript
- celebrate milestones with a flourish animation
- document the new dynamic background feature

## Testing
- `node -c script.js`

------
https://chatgpt.com/codex/tasks/task_e_687f74bf4104832c8fed516e5389aced