### PR TITLE
Add automation for peace builders

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Each click symbolizes an act of peace, kindness, or positive dialogue, gradually
 
 - **Click:** Plant a "Seed of Peace" that visually transforms the landscape.
 - **Idle Actions:** Automate peace-building through symbolic characters (Teachers, Advocates, Artists).
+  - Purchase with peace seeds: Teacher (100 seeds, 1 seed/sec), Peace Advocate (500 seeds, 5 seeds/sec), Artist (1000 seeds, 12 seeds/sec).
 - **Milestones:** Unlock educational content, real-world stories of peace, and conflict resolution inspiration.
 - **Dynamic Background:** Starts in a blurred grayscale state and becomes clearer with each planted seed, celebrating milestones with a colorful flourish.
 

--- a/index.html
+++ b/index.html
@@ -35,7 +35,11 @@ CopyLeft 2020 Michael Rouves
 	<!-- SHOP BUTTONS -->
 	<button id="b1" class="button" disabled><b></b>Money per Click x2</button>
 	<button id="b2" class="button" disabled><b></b>+5 every second</button>
-	<button id="b3" class="button" disabled><b></b>Auto Gain x2</button>
+        <button id="b3" class="button" disabled><b></b>Auto Gain x2</button>
+        <!-- PEACE-BUILDER CHARACTERS -->
+        <button id="teacher" class="button builder"><b></b>📚👩‍🏫 Teacher</button>
+        <button id="advocate" class="button builder"><b></b>🗣️ Peace Advocate</button>
+        <button id="artist" class="button builder"><b></b>🎨 Artist</button>
 	
 	<!-- Load Javascript -->
 	<script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -25,6 +25,14 @@ var money = 0,//global player's money
         interval,//auto money interval
         peaceSeeds = 0;//counts planted seeds
 
+//peace builder automation
+var seedRate = 0;
+var builders = {
+  teacher:   {element: document.getElementById("teacher"),   cost: 100,  rate: 1,  count: 0, emoji: "📚👩‍🏫", label: "Teacher"},
+  advocate:  {element: document.getElementById("advocate"),  cost: 500, rate: 5,  count: 0, emoji: "🗣️",    label: "Peace Advocate"},
+  artist:    {element: document.getElementById("artist"),    cost: 1000, rate: 12, count: 0, emoji: "🎨",    label: "Artist"},
+};
+
 //background effect variables
 var background = document.getElementById("background"),
         blurLevel = 5,
@@ -47,8 +55,9 @@ function updateMoney(check=true) {//update html money txt
   element.money.innerHTML = text;
   if(check){checkPrices();}
 }
-function updateSeeds(){
+function updateSeeds(check=true){
   element.seeds.innerHTML = "Peace Seeds planted: " + peaceSeeds;
+  if(check){checkBuilderPrices();}
 }
 function updateBackground(){
   blurLevel = Math.max(0, blurLevel - 0.1);
@@ -68,13 +77,41 @@ function autoMoney(amount) {//auto add money every interval
 
 //called when a shop Element was bought
 function checkPrices() {
-	//Check price for each shop element
-	//unlock purchase button if enough money
-	for(let i=0;i<shop.length;i++){
-		if(money >= shop[i].price){
-			shop[i].element.disabled = false;
-		}
-	}
+        //Check price for each shop element
+        //unlock purchase button if enough money
+        for(let i=0;i<shop.length;i++){
+                if(money >= shop[i].price){
+                        shop[i].element.disabled = false;
+                }
+        }
+}
+
+function checkBuilderPrices(){
+  for(const key in builders){
+    const b = builders[key];
+    if(peaceSeeds >= b.cost){
+      b.element.disabled = false;
+    }else{
+      b.element.disabled = true;
+    }
+  }
+}
+
+function updateBuilderText(builder){
+  builder.element.getElementsByTagName("b")[0].innerHTML =
+    '<b>' + builder.cost + ' seeds: </b>' + builder.emoji + ' ' + builder.label +
+    ' (' + builder.count + ')';
+}
+
+function purchaseBuilder(type){
+  const b = builders[type];
+  if(peaceSeeds < b.cost) return;
+  peaceSeeds -= b.cost;
+  b.count += 1;
+  seedRate += b.rate;
+  updateSeeds(false);
+  updateBuilderText(b);
+  checkBuilderPrices();
 }
 //called when a shop Element was bought
 function onBuy(obj) {
@@ -162,6 +199,21 @@ updateSeeds(); //seed counter
 for (let i=0;i<shop.length;i++){
         shop[i].update() //buttons txt & price
 }
+
+for(const key in builders){
+  builders[key].element.onclick = purchaseBuilder.bind(null, key);
+  updateBuilderText(builders[key]);
+}
+checkBuilderPrices();
+
+setInterval(function(){
+  if(seedRate>0){
+    peaceSeeds += seedRate;
+    updateSeeds(false);
+    updateBackground();
+    checkMilestones();
+  }
+},1000);
 
 //set main clicker function onClick
 element.clicker.onclick = function() {

--- a/style.css
+++ b/style.css
@@ -87,18 +87,24 @@ body{
 			================= SHOP =================
 */
 .button{
-	width: 200;height: 50;
-	position: absolute;
-	left: 87%;
-	transform: translate(-50%, -50%);
+        width: 200;height: 50;
+        position: absolute;
+        left: 87%;
+        transform: translate(-50%, -50%);
 }
 .button:disabled{
-	background-color: #B3B3B3;
+        background-color: #B3B3B3;
 }
 
 #b1{top:22%}
 #b2{top:32%}
 #b3{top:42%}
+
+/* Peace builder buttons */
+.builder{ left:13%; }
+#teacher{top:60%}
+#advocate{top:70%}
+#artist{top:80%}
 
 
 /* 


### PR DESCRIPTION
## Summary
- allow purchasing Teacher, Peace Advocate and Artist with seeds
- automatically plant seeds every second from purchased characters
- style and position new builder buttons
- document peace builder costs in README

## Testing
- `node -c script.js`

------
https://chatgpt.com/codex/tasks/task_e_6880b7cd85e4832cb1c4be2b401cb399