### PR TITLE
Improve milestone popup design

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,8 +42,10 @@ CopyLeft 2020 Michael Rouves
         <button id="artist" class="button builder"><b></b>🎨 Artist</button>
 
         <div id="milestone-overlay">
-            <div id="milestone-content"></div>
-            <button id="milestone-close">Close</button>
+            <div id="milestone-card">
+                <p id="milestone-content"></p>
+                <div id="milestone-close">Close</div>
+            </div>
         </div>
 
         <!-- Placeholder for future ethical advertising -->

--- a/style.css
+++ b/style.css
@@ -70,8 +70,7 @@ body {
   pointer-events: none;
 }
 
-.button,
-#milestone-close {
+.button {
   padding: 1rem 2rem;
   border: none;
   border-radius: 12px;
@@ -94,12 +93,27 @@ body {
   left: 0;
   width: 100%;
   height: 100%;
-  background: rgba(0,0,0,0.8);
-  color: #fff;
+  background: rgba(0,0,0,0.7);
   justify-content: center;
   align-items: center;
   flex-direction: column;
   z-index: 5;
+}
+
+#milestone-card {
+  background: #ffffff;
+  border-radius: 12px;
+  box-shadow: 0 4px 8px rgba(0,0,0,0.2);
+  text-align: center;
+  padding: 20px;
+  font-size: 18px;
+  color: #333;
+}
+
+#milestone-close {
+  margin-top: 10px;
+  font-weight: bold;
+  cursor: pointer;
 }
 
 #milestone-overlay.show {


### PR DESCRIPTION
## Summary
- restyle milestone popup overlay and card
- adjust close button to look like subtle text link

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6880eadccaac832c9759c7eb74fea97f